### PR TITLE
Connection、ConnMgr接入ManagerBase、MemberBase实现

### DIFF
--- a/project/server/engine/ecs/EcsDefine.hpp
+++ b/project/server/engine/ecs/EcsDefine.hpp
@@ -51,13 +51,13 @@ typedef int64_t ComponentId;
 typedef int32_t ComponentTemplateId; // 模板id
 
 extern inline GameObjectId GenerateGameObjectID() 
-{ return bbt::uuid::EasyID<bbt::uuid::EM_AUTO_INCREMENT, EM_Mist_GameObjectId>::GenerateID() ; }
+{ return bbt::uuid::EasyID<bbt::uuid::emEasyID::EM_AUTO_INCREMENT, EM_Mist_GameObjectId>::GenerateID() ; }
 
 extern inline bool GameObjectIDInvalid(GameObjectId id)
 { return (id <= 0); }
 
 extern inline ComponentId GenerateComponentID() 
-{ return bbt::uuid::EasyID<bbt::uuid::EM_AUTO_INCREMENT, EM_Mist_ComponentId>::GenerateID(); }
+{ return bbt::uuid::EasyID<bbt::uuid::emEasyID::EM_AUTO_INCREMENT, EM_Mist_ComponentId>::GenerateID(); }
 
 extern inline bool ComponentIDInvalid(ComponentId id)
 { return (id <= 0); }

--- a/project/server/share/ecs/entity/network/Acceptor.cc
+++ b/project/server/share/ecs/entity/network/Acceptor.cc
@@ -152,9 +152,17 @@ void Acceptor::OnAccept(int fd, const util::network::Address& peer_addr)
         auto run_in_target_thread = m_load_blance_cb();
         DebugAssertWithInfo(run_in_target_thread, "loadblance error!");
         auto new_conn = util::network::ev::evConnMgr::GetInstance()->CreateConn(run_in_target_thread, fd, peer_addr, m_listen_addr);
-        //TODO 二、初始化游戏对象
+        //TODO 回调连接对象
         GAME_BASE_LOG_INFO("[Acceptor::OnAccept] Acceptor ==> Client IP:{%s}", peer_addr.GetIPPort().c_str());
+        DebugAssertWithInfo(m_onconnect_cb == nullptr , "onconnect callback is null!");
+        m_onconnect_cb(new_conn);
     }
+}
+
+void Acceptor::SetOnConnect(const OnAcceptCallback& cb)
+{
+    DebugAssertWithInfo(m_onconnect_cb == nullptr, "repeat regist event!");
+    m_onconnect_cb = cb;
 }
 
 }

--- a/project/server/share/ecs/entity/network/Acceptor.cc
+++ b/project/server/share/ecs/entity/network/Acceptor.cc
@@ -151,11 +151,12 @@ void Acceptor::OnAccept(int fd, const util::network::Address& peer_addr)
         DebugAssertWithInfo(m_load_blance_cb != nullptr, "loadblance callback not initialized!");
         auto run_in_target_thread = m_load_blance_cb();
         DebugAssertWithInfo(run_in_target_thread, "loadblance error!");
-        auto new_conn = util::network::ev::evConnMgr::GetInstance()->CreateConn(run_in_target_thread, fd, peer_addr, m_listen_addr);
+        auto new_conn = util::network::ev::evConnMgr::GetInstance()->Create<util::network::ev::evConnection>(run_in_target_thread, fd, peer_addr, m_listen_addr);
         //TODO 回调连接对象
         GAME_BASE_LOG_INFO("[Acceptor::OnAccept] Acceptor ==> Client IP:{%s}", peer_addr.GetIPPort().c_str());
         DebugAssertWithInfo(m_onconnect_cb == nullptr , "onconnect callback is null!");
-        m_onconnect_cb(new_conn);
+        if(m_onconnect_cb)
+            m_onconnect_cb(new_conn);
     }
 }
 

--- a/project/server/share/ecs/entity/network/Acceptor.hpp
+++ b/project/server/share/ecs/entity/network/Acceptor.hpp
@@ -61,7 +61,7 @@ private:
     short           m_listen_port;
     util::network::Address    m_listen_addr;
     LoadBlanceFunc      m_load_blance_cb{nullptr};
-    OnAcceptCallback   m_onconnect_cb{nullptr};
+    OnAcceptCallback    m_onconnect_cb{nullptr};
 };
 
 }// namespace end

--- a/project/server/share/ecs/entity/network/Acceptor.hpp
+++ b/project/server/share/ecs/entity/network/Acceptor.hpp
@@ -17,6 +17,7 @@ class Acceptor
 
 public:
     typedef std::function<util::network::IOThread*()> LoadBlanceFunc;
+    typedef std::function<void(util::network::ConnectionSPtr)> OnAcceptCallback;
 
     /* 创建listen 套接字 */
     Acceptor(std::string ip, short port);
@@ -33,7 +34,20 @@ public:
     int SetNonBlock();
     /* 将accept事件注册到event base中 */
     int RegistInEvBase(event_base*);
+
+    /**
+     * @brief 设置连接到达时负载均衡回调
+     * 
+     * @param cb 
+     */
     void SetLoadBlance(const LoadBlanceFunc& cb);
+
+    /**
+     * @brief 设置新连接建立时的回调
+     * 
+     * @param cb 
+     */
+    void SetOnConnect(const OnAcceptCallback& cb);
 private:
     void Init();
     void Destory();
@@ -46,7 +60,8 @@ private:
     std::string     m_listen_ip;
     short           m_listen_port;
     util::network::Address    m_listen_addr;
-    LoadBlanceFunc  m_load_blance_cb;
+    LoadBlanceFunc      m_load_blance_cb{nullptr};
+    OnAcceptCallback   m_onconnect_cb{nullptr};
 };
 
 }// namespace end

--- a/project/server/share/ecs/entity/network/Network.cc
+++ b/project/server/share/ecs/entity/network/Network.cc
@@ -176,6 +176,31 @@ void Network::OnUpdate()
     SyncStop();
 }
 
+void Network::SetOnConnect(const OnConnectCallback& cb)
+{
+    DebugAssertWithInfo(m_onconnect_event == nullptr, "repeat register event!");
+    m_onconnect_event = cb;
+}
+
+void Network::SetOnAccept(const OnAcceptCallback& cb)
+{
+    DebugAssertWithInfo(m_onaccept_event == nullptr, "repeat register event!");
+    m_onaccept_event = cb;
+    m_acceptor.SetOnConnect([this](const util::network::ConnectionSPtr& conn){ this->m_onconnect_event(conn); });
+}
+
+void Network::SetOnClose(const OnCloseCallback& cb)
+{
+    DebugAssertWithInfo(m_onclose_event == nullptr, "repeat register event!");
+    m_onclose_event = cb;
+}
+
+void Network::SetOnTimeOut(const OnTimeOutCallback& cb)
+{
+    DebugAssertWithInfo(m_ontimeout_event == nullptr, "repeat register event!");
+    m_ontimeout_event = cb;
+}
+
 #pragma region "工具函数"
 
 util::network::IOThread* Network::NewConnLoadBlance()

--- a/project/server/share/session/SessionBase.cc
+++ b/project/server/share/session/SessionBase.cc
@@ -1,0 +1,1 @@
+#include "./SessionBase.hpp"

--- a/project/server/share/session/SessionBase.hpp
+++ b/project/server/share/session/SessionBase.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+
+namespace share::session
+{
+
+class SessionBase
+{
+public:
+
+private:
+
+};
+
+};

--- a/project/server/util/managerbase/ManagerBaseTpl.hpp
+++ b/project/server/util/managerbase/ManagerBaseTpl.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "./ManagerBase.hpp"
+#include "util/log/Log.hpp"
 
 
 namespace util::managerbase
@@ -46,7 +47,10 @@ std::shared_ptr<MemberBaseChildType> ManagerBase<_KeyType, _MemType>::Create(Ini
 template<typename _KeyType, typename _MemType>
 MemberBase<_KeyType, _MemType>::~MemberBase()
 {
-    m_mgr->OnMemberDestory(m_key);
+    bool isok = m_mgr->OnMemberDestory(m_key);
+    DebugAssertWithInfo(isok, "destory a member failed!");
+    if(!isok)
+        BBT_BASE_LOG_ERROR("[MemberBase::~MemberBase] destory a member failed!");
 }
 
 

--- a/project/server/util/network/ConnMgr.cc
+++ b/project/server/util/network/ConnMgr.cc
@@ -1,4 +1,5 @@
 #include "util/network/ConnMgr.hpp"
+#include "util/log/Log.hpp"
 
 
 namespace util::network
@@ -10,6 +11,70 @@ ConnMgr::ConnMgr()
 
 ConnMgr::~ConnMgr()
 {
+}
+
+ConnMgr::Result ConnMgr::Search(KeyType key)
+{
+    auto it = m_conn_map.find(key);
+    if(it == m_conn_map.end())
+        return {nullptr, false};
+
+    auto ptr = (it->second).lock();
+    if(ptr == nullptr)
+        BBT_BASE_LOG_WARN("[ConnMgr::Search] connect is not exist! key=%d", key);
+
+    return {ptr, true};
+}
+
+bool ConnMgr::IsExist(KeyType key)
+{
+    auto it = m_conn_map.find(key);
+    return !(it == m_conn_map.end());
+}
+
+bool ConnMgr::OnMemberCreate(MemberPtr member_ptr)
+{
+    if(member_ptr == nullptr)
+        BBT_BASE_LOG_WARN("[ConnMgr::OnMemberCreate] connect can`t convert to derive class!");
+
+    bool isok = false;
+    {
+        std::lock_guard<std::mutex> lock(m_conn_map_mutex);
+        auto [it, existed] = m_conn_map.insert(std::make_pair(member_ptr->GetMemberId(), member_ptr));
+        isok = existed;
+    }
+    if(!isok)
+        GAME_BASE_LOG_DEBUG("[ConnMgr::OnMemberCreate] this is an unusual behavior, repeat init or no release prev conn! sockfd=%d", member_ptr->GetSocket());
+    else
+        GAME_EXT1_LOG_DEBUG("[ConnMgr::OnMemberCreate] ConnMgr <== init connection! sockfd=%d", member_ptr->GetSocket());
+    return isok;
+}
+
+bool ConnMgr::OnMemberDestory(KeyType connid)
+{
+    DebugAssert(connid >= 0);
+    bool isok = false;
+    ConnectionSPtr conn_ptr = nullptr;
+    {
+        std::lock_guard<std::mutex> lock(m_conn_map_mutex);
+        auto it = m_conn_map.find(connid);
+        if(it != m_conn_map.end())
+        {
+            isok = true;
+            m_conn_map.erase(it);
+        }
+
+        conn_ptr = (it->second).lock();
+        if(!isok)
+            GAME_BASE_LOG_WARN("[ConnMgr::OnMemberDestory] this is an unuseal behavior, look out connection life cycle!");
+    }
+
+    return isok;
+}
+
+ConnMgr::KeyType ConnMgr::GenerateKey(MemberPtr)
+{
+    return GenerateConnectID();
 }
 
 }// namespace end

--- a/project/server/util/network/ConnMgr.hpp
+++ b/project/server/util/network/ConnMgr.hpp
@@ -1,10 +1,22 @@
 #pragma once
 #include "util/network/Connection.hpp"
+#include "util/managerbase/ManagerBase.hpp"
+#include "./Define.hpp"
+
+
+#define evConnectionDeriveClassDef \
+    FlagManagedByManagerBase(util::network::ConnectId, util::network::Connection)
 
 namespace util::network
 {
 
-class ConnMgr
+namespace ev
+{
+class evConnection;
+}
+
+class ConnMgr:
+    public util::managerbase::ManagerBase<ConnectId, Connection>
 {
 public:
     ConnMgr();
@@ -12,8 +24,21 @@ public:
 
     /* 创建Conn的接口 */
     // virtual ConnectionSPtr CreateConn(int newfd, void* args) = 0;
+
+    virtual Result Search(KeyType key) override final;
+    virtual bool IsExist(KeyType key) override final;
+protected:
+    virtual bool OnMemberCreate(MemberPtr member) override final;
+
+    virtual bool OnMemberDestory(KeyType member) override final;
+
+    virtual KeyType GenerateKey(MemberPtr) override final;
+
     /* 通过socketfd获取连接 */
-    virtual ConnectionWKPtr GetConnBySocket(int sockfd) = 0; 
+    virtual ConnectionWKPtr GetConnBySocket(int sockfd) = 0;
+private:
+    std::map<ConnectId, ConnectionWKPtr> m_conn_map;
+    std::mutex m_conn_map_mutex;
 };
 
 }// namespace end

--- a/project/server/util/network/Connection.cc
+++ b/project/server/util/network/Connection.cc
@@ -2,5 +2,35 @@
 
 namespace util::network
 {
-Connection::~Connection(){}
+
+Connection::Connection(int sockfd, const Address& peer, const Address& local)
+    :m_sockfd(sockfd),
+    m_peer_addr(peer),
+    m_local_addr(local)
+{
+
+}
+
+Connection::~Connection()
+{
+    GAME_EXT1_LOG_INFO("[Connection::~Connection] release connection! sockfd=%d", GetSocket());
+}
+
+int Connection::GetSocket()
+{
+    return m_sockfd;
+}
+
+const Address& Connection::GetLocalIPAddress() const
+{
+    return m_local_addr;
+}
+
+const Address& Connection::GetPeerIPAddress() const
+{
+    return m_peer_addr;
+}
+
+
+
 }

--- a/project/server/util/network/Connection.hpp
+++ b/project/server/util/network/Connection.hpp
@@ -4,6 +4,7 @@
 #include <optional>
 #include "util/typedef/NamespaceType.hpp"
 #include "util/network/IPAddress.hpp"
+#include "./Define.hpp"
 
 namespace util::network
 {
@@ -20,10 +21,12 @@ enum ConnStatus
     Disconnected = 3,       // 连接已断开
 };
 
-class Connection
+class Connection:
+    public util::managerbase::MemberBase<ConnectId, Connection>,
+    public std::enable_shared_from_this<Connection>
 {
 public:
-    Connection(){}
+    Connection(int sockfd, const Address& peer, const Address& local);
     virtual ~Connection() = 0;
 
     /**
@@ -66,17 +69,24 @@ public:
      * @brief 获取对端的ip地址
      * @return Address 
      */
-    virtual const Address& GetPeerIPAddress() const = 0;
+    virtual const Address& GetPeerIPAddress() const;
 
     /**
      * @brief 获取本地的ip地址
      * 
      * @return Address 
      */
-    virtual const Address& GetLocalIPAddress() const = 0;
+    virtual const Address& GetLocalIPAddress() const;
 
-private:
+    int GetSocket();
 
+protected:
+
+    int         m_sockfd{-1};
+    volatile ConnStatus  m_status{ConnStatus::Done};
+    util::network::Address  m_local_addr;
+    util::network::Address  m_peer_addr;
+    std::mutex  m_mutex;
 };
 
 

--- a/project/server/util/network/Define.hpp
+++ b/project/server/util/network/Define.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include <iostream>
+#include "bbt/uuid/EasyID.hpp"
+#include "util/managerbase/ManagerBase.hpp"
+
+namespace util::network
+{
+
+typedef int64_t ConnectId;
+
+enum GenerateKey {
+    EM_ConnectId = 1,
+};
+
+extern inline ConnectId GenerateConnectID()
+{ return bbt::uuid::EasyID<bbt::uuid::emEasyID::EM_AUTO_INCREMENT, GenerateKey::EM_ConnectId>::GenerateID(); }
+
+}

--- a/project/server/util/network/libevent/evConnMgr.cc
+++ b/project/server/util/network/libevent/evConnMgr.cc
@@ -64,55 +64,6 @@ void evConnMgr::SetIOThread(IOThread* thread)
         m_thread = thread;
     else
         GAME_BASE_LOG_WARN("[evConnMgr::SetIOThread] repeat init io thread!");
-}    
-
-ConnectionSPtr evConnMgr::CreateConn(IOThread* thread, int newfd, Address peer_ip, Address local_ip)
-{
-    auto new_conn = std::make_shared<evConnection>(thread, newfd, peer_ip, local_ip);
-
-    OnConnInit(new_conn);
-
-    new_conn->SetOnDestory([this](evConnectionSPtr conn){
-        OnConnDestory(conn);
-    });
-
-    return new_conn;
-}
-
-void evConnMgr::OnConnInit(evConnectionSPtr conn)
-{
-    DebugAssert(conn != nullptr);
-    bool isok = false;
-    {
-        std::lock_guard<std::mutex> lock(m_conn_map_mutex);
-        auto [it, exist] = m_conn_map.insert(std::make_pair(conn->GetSocket(), conn));
-        isok = exist;
-    }
-    if(!isok)
-        GAME_BASE_LOG_WARN("[evConnMgr::OnConnDestory] this is an unusual behavior, repeat init or no release prev conn, beacuse socket fd can be reused! sockfd=%d", conn->GetSocket());
-    else
-        GAME_EXT1_LOG_DEBUG("[evConnMgr::OnConnDestory] ConnMgr <== init connection! sockfd=%d", conn->GetSocket());
-}
-
-void evConnMgr::OnConnDestory(evConnectionSPtr conn)
-{
-    DebugAssert(conn != nullptr);
-    bool isok = false;
-    {
-        std::lock_guard<std::mutex> lock(m_conn_map_mutex);
-        auto it = m_conn_map.find(conn->GetSocket());
-        if(it != m_conn_map.end())
-        {
-            isok = true;
-            m_conn_map.erase(it);
-        }
-    }
-
-    if(!isok)
-        GAME_BASE_LOG_WARN("[evConnMgr::OnConnDestory] this is an unusual behavior, look out connection life cycle!");
-    else
-        GAME_EXT1_LOG_DEBUG("[evConnMgr::OnConnDestory] ConnMgr ==> release connection! sockfd=%d", conn->GetSocket());
-
 }
 
 ConnectionWKPtr evConnMgr::GetConnBySocket(int sockfd)

--- a/project/server/util/network/libevent/evConnMgr.hpp
+++ b/project/server/util/network/libevent/evConnMgr.hpp
@@ -18,16 +18,6 @@ public:
     static const std::unique_ptr<evConnMgr>& GetInstance();
     virtual ~evConnMgr();
 
-    /**
-     * @brief 创建一个 evConnection 对象，并返回指针
-     * 
-     * @param thread 这个连接IO活跃所在的线程
-     * @param newfd 这个连接对应的连接
-     * @param peer_ip 对端的ip、port
-     * @param local_ip 本地的ip、port
-     * @return ConnectionSPtr 
-     */
-    virtual ConnectionSPtr CreateConn(IOThread* thread, int newfd, Address peer_ip, Address local_ip) BBTATTR_FUNC_RetVal;
     /*XXX 通过socketfd获取连接，寻求更好的方式，暴露出socket fd可能是不好的，可以加入句柄/id */
     virtual ConnectionWKPtr GetConnBySocket(int sockfd); 
 
@@ -38,9 +28,6 @@ private:
 
     void InitCfg();
     void InitEvent();
-
-    void OnConnInit(evConnectionSPtr conn);
-    void OnConnDestory(evConnectionSPtr conn);
 private:
     /* 心跳事件控制 */
     void InitHeartBeatEvent();

--- a/project/server/util/network/libevent/evIOThread.cc
+++ b/project/server/util/network/libevent/evIOThread.cc
@@ -92,12 +92,17 @@ EventId evIOThread::RegisterEvent(std::shared_ptr<evEvent> evptr)
 
 int evIOThread::UnRegisterEvent(EventId eventid)
 {
-    auto id = m_event_map.erase(eventid);
-    if(id <= 0) {
+    auto it = m_event_map.find(eventid);
+    if(it == m_event_map.end())
+    {
         return -1;
     }
+    
+    m_event_map.erase(it);
 
-    return 0;
+    auto isok = (it->second)->UnRegister();
+
+    return isok;
 }
 
 }// namespace end


### PR DESCRIPTION
使用manager类来做可以统一创建、释放并隐藏入口；
接入后内存管理更方便，约等于直接重构了；
但是后续最好还是提供一些弱引用访问接口，否则还是无法避免对象丢失，好在连接的控制大多都被控制在底层中，涉及的问题不会很复杂，可以做到逻辑自洽；